### PR TITLE
Ensure that .chw files created from NSIS .chm documentation are ignored by git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.pyc
 *.pyo
 python/comtypes/gen
+*.chw


### PR DESCRIPTION
When browsing NSIS documentation which is in .chm format Windows sometimes creates `.chw` files - I believe they're used when using search functionality to store previously searched terms etc. These files should be ignored by git.