### PR TITLE
Add wxPython  4.2.2a0205c7c1b

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -82,6 +82,14 @@ Use the following steps to build a version of the brlapi Python extension that i
 Used to generate and format NVDA documentation.
 Will be abandoned soon in favour of markdown formatting.
 
+### wxPython
+
+Generally release builds of wxPython should be used from pip.
+However, due to an issue in wxPython that has not made it to a release quality build, we are stuck on alpha snapshots.
+
+Windows x86 alpha builds can be found via Robin Dunn's build pipeline:
+https://alldunn.visualstudio.com/wxPython-CI/_build?view=runs
+
 ## lilli.dll
 
 A braille display driver dll.


### PR DESCRIPTION
NVDA PR to incorporate changes: https://github.com/nvaccess/nvda/pull/16257

Generally release builds of wxPython should be used from pip.
However, due to an issue in wxPython (https://github.com/nvaccess/nvda/issues/15714) that has not made it to a release quality build, we are stuck on alpha snapshots.

The build used is from:

- https://alldunn.visualstudio.com/wxPython-CI/_build/results?buildId=1246&view=results
- https://github.com/wxWidgets/Phoenix/commit/0205c7c1b9022a5de3e3543f9304cfe53a32b488

Windows x86 alpha builds can be found via Robin Dunn's build pipeline:
https://alldunn.visualstudio.com/wxPython-CI/_build?view=runs

I have asked Robin what the quality of alpha builds are - i.e. if they throw errors, log, or otherwise act differently due to not being an official release