### PR TITLE
Remove wxPython 

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -77,14 +77,6 @@ Use the following steps to build a version of the brlapi Python extension that i
     - `libgcc_s_dw2-1.dll` from `brltty-win-X.X-0-libusb\bin\libgcc_s_dw2-1.dll`
     - `brlapi-*.dll` from `brltty-win-X.X-0-libusb\brltty-win-6.6-0-libusb\bin\brlapi-*.dll`
 
-### wxPython
-
-Generally release builds of wxPython should be used from pip.
-However, due to an issue in wxPython that has not made it to a release quality build, we are stuck on alpha snapshots.
-
-Windows x86 alpha builds can be found via Robin Dunn's build pipeline:
-https://alldunn.visualstudio.com/wxPython-CI/_build?view=runs
-
 ## lilli.dll
 
 A braille display driver dll.


### PR DESCRIPTION
follow up to PR https://github.com/nvaccess/nvda/pull/17181 which updated wxPython to 4.2.2, using 32-bit wheel hosted on PyPI, rather than a custom build