### PR TITLE
Add support for uv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
+__pycache__
 *.pyc
 *.pyo
 python/comtypes/gen
 *.chw
+*.egg-info

--- a/.python-version
+++ b/.python-version
@@ -1,0 +1,1 @@
+cpython-3.11-windows-x86-none

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,17 @@
+[project]
+name = "nvda-miscdeps"
+version = "20250419"
+readme = "readme.md"
+requires-python = ">=3.11,<3.12"
+
+[project.urls]
+Homepage = "https://www.nvaccess.org/"
+Repository = "https://github.com/nvaccess/nvda-miscDeps.git"
+
+[build-system]
+requires = ["setuptools~=72.0"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools]
+package-dir = {"" = "python"}
+include-package-data = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,12 +1,12 @@
 [project]
-name = "nvda-miscdeps"
+name = "nvda-misc-deps"
 version = "20250419"
 readme = "readme.md"
 requires-python = ">=3.11,<3.12"
 
 [project.urls]
 Homepage = "https://www.nvaccess.org/"
-Repository = "https://github.com/nvaccess/nvda-miscDeps.git"
+Repository = "https://github.com/nvaccess/nvda-misc-deps.git"
 
 [build-system]
 requires = ["setuptools~=72.0"]


### PR DESCRIPTION
See https://github.com/nvaccess/nvda/pull/17978
This ensures that python miscDeps become a python package that can be included as dependency in uv. Then it is no longer necessary to use a sourceEnv script.