### PR TITLE
Update to Python 3.13.7

### DIFF
--- a/.python-versions
+++ b/.python-versions
@@ -1,4 +1,3 @@
 cpython-3.11.9-windows-x86-none
-cpython-3.13.6-windows-x86-none
-cpython-3.11.9-windows-x86_64-none
-cpython-3.13.6-windows-x86_64-none
+cpython-3.13.7-windows-x86-none
+cpython-3.13.7-windows-x86_64-none


### PR DESCRIPTION
Also removed 3.11.9x64, as we are not using it any more.