### PR TITLE
Update dump_syms

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -97,5 +97,5 @@ M4 is necessary to compile liblouis tables containing macros.
 
 ### symbols
 
-1. Download the latest [`dump_syms.exe`](https://github.com/mozilla/gecko-dev/blob/master/toolkit/crashreporter/google-breakpad/src/tools/windows/binaries/dump_syms.exe) ([last known version](https://github.com/mozilla/gecko-dev/blob/b0e9d95a41068be0f41f30e632ef93ab5999767a/toolkit/crashreporter/google-breakpad/src/tools/windows/binaries/dump_syms.exe))
-1. Replace `dump_syms.exe`
+1. [Build Firefox](https://firefox-source-docs.mozilla.org/setup/windows_build.html)
+1. Copy `dump_syms.exe` from `%USERPROFILE\.mozbuild\dump_syms`


### PR DESCRIPTION
Update dump_syms to a copy extracted from a Firefox build environment, commit 8e5d58cfed616cb90586c614e53d8ab1ffc8af27.

Mozilla completely reimplemented this a while ago with better dumping and without a dependency on msdia*.dll.