### PR TITLE
Mention brltty upstream rather than fork

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -38,7 +38,7 @@ This will require a significant rewrite of the papenmeier display driver.
 
 Used for BrlTTY.
 
-To get the necessary files, you can extract them from a build artifact produced by [GitHub Actions in the NV Access fork of the brlTTY repository](https://github.com/nvaccess/brltty/actions).
+To get the necessary files, you can extract them from a build artifact produced by [GitHub Actions of the brlTTY repository](https://github.com/brltty/brltty/actions).
 
 The following files should be updated:
 


### PR DESCRIPTION
Github workflow was merged in https://github.com/brltty/brltty/commit/a8a03753290c780bfa98e889bf1fd9142ad0f383 . Updated the readme to point at upstream. This doesn't require an update of the submodule in the NVDA main repo.